### PR TITLE
Feature/ready4encryption

### DIFF
--- a/src/main/java/app/AppClient.java
+++ b/src/main/java/app/AppClient.java
@@ -6,6 +6,7 @@ import handler.AppClientEventHandler;
 import stub.AppClientStub;
 import views.AppClientFrame;
 
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 
 public class AppClient {
@@ -13,14 +14,14 @@ public class AppClient {
   private final AppClientFrame appFrame;
   private final AppClientStub stub;
 
-  public AppClient() {
+  public AppClient() throws NoSuchAlgorithmException {
     appFrame = new AppClientFrame();
     stub = new AppClientStub();
     AppClientEventHandler clientEventHandler = new AppClientEventHandler(stub, appFrame);
     stub.setAppEventHandler(clientEventHandler);
   }
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws NoSuchAlgorithmException {
     AppClient client = new AppClient();
     client.appFrame.loginCallback = new LoginCallback() {
       @Override

--- a/src/main/java/stub/AppClientStub.java
+++ b/src/main/java/stub/AppClientStub.java
@@ -5,16 +5,34 @@ import kr.ac.konkuk.ccslab.cm.event.CMDummyEvent;
 import kr.ac.konkuk.ccslab.cm.info.CMInteractionInfo;
 import kr.ac.konkuk.ccslab.cm.manager.CMEventManager;
 import kr.ac.konkuk.ccslab.cm.stub.CMClientStub;
-import java.util.ArrayList;
-import java.util.List;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import java.io.UnsupportedEncodingException;
+import java.security.*;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.*;
 
 public class AppClientStub extends CMClientStub {
 
   public List<Group> groupList = new ArrayList<>();
   public static final int totalGroupCount = 5; // cm-session1.conf에 선언되어 있는 group의 개수
 
-  public AppClientStub() {
+  private KeyPair keyPair; // PrivateKey + PublicKey
+  private PublicKey publicKey;
+  private PrivateKey privateKey;
+
+  private Map<String, PublicKey> publicKeyMap = new HashMap<String, PublicKey>(); // Other Client's publicKeyMap for encryption
+
+  public AppClientStub() throws NoSuchAlgorithmException {
     super();
+    keyPair = genRSAKeyPair();
+    publicKey = keyPair.getPublic();
+    privateKey = keyPair.getPrivate();
   }
 
   public void createAndEnterChatRoom(String chatRoomName) {
@@ -72,4 +90,65 @@ public class AppClientStub extends CMClientStub {
     due.setDummyInfo(sb.toString());
     CMEventManager.unicastEvent(due, strDefServer, getCMInfo()); // Dummy Event 전달
   }
+
+  // 1024비트 RSA 키쌍을 생성합니다.
+  public static KeyPair genRSAKeyPair() throws NoSuchAlgorithmException {
+    SecureRandom secureRandom = new SecureRandom();
+    KeyPairGenerator gen;
+    gen = KeyPairGenerator.getInstance("RSA");
+    gen.initialize(1024, secureRandom);
+    KeyPair keyPair = gen.genKeyPair();
+    return keyPair;
+  }
+
+  // Public Key로 RSA 암호화를 수행합니다.
+  public static String encryptRSA(String plainText, PublicKey publicKey) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
+    Cipher cipher = Cipher.getInstance("RSA");
+    cipher.init(Cipher.ENCRYPT_MODE, publicKey);
+    byte[] bytePlain = cipher.doFinal(plainText.getBytes());
+    String encrypted = Base64.getEncoder().encodeToString(bytePlain);
+    return encrypted;
+  }
+
+  // Private Key로 RAS 복호화를 수행합니다.
+  public static String decryptRSA(String encrypted, PrivateKey privateKey) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, UnsupportedEncodingException {
+    Cipher cipher = Cipher.getInstance("RSA");
+    byte[] byteEncrypted = Base64.getDecoder().decode(encrypted.getBytes());
+    cipher.init(Cipher.DECRYPT_MODE, privateKey);
+    byte[] bytePlain = cipher.doFinal(byteEncrypted);
+    String decrypted = new String(bytePlain, "utf-8");
+    return decrypted;
+  }
+
+  // 공개키를 Base64 인코딩한 문자일을 만듭니다. (문자열로 만든 후 broadcast 실)시
+  public static String publicKey2Base64String(PublicKey publicKey) {
+    byte[] bytePublicKey = publicKey.getEncoded();
+    String base64PublicKey = Base64.getEncoder().encodeToString(bytePublicKey);
+    return base64PublicKey;
+  }
+
+  // 개인키를 Base64 인코딩한 문자일을 만듭니다. (하지만 사용할 일 X)
+  public static String privateKey2Base64String(PrivateKey privateKey) {
+    byte[] bytePrivateKey = privateKey.getEncoded();
+    String base64PrivateKey = Base64.getEncoder().encodeToString(bytePrivateKey);
+    return base64PrivateKey;
+  }
+
+  // Base64 엔코딩된 개인키 문자열로부터 PrivateKey를 얻는다. (하지만 사용할 일 X)
+  public static PrivateKey getPrivateKeyFromBase64String(final String keyString) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    final String privateKeyString = keyString.replaceAll("\\n", "").replaceAll("-{5}[ a-zA-Z]*-{5}", "");
+    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+    PKCS8EncodedKeySpec keySpecPKCS8 = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateKeyString));
+    return keyFactory.generatePrivate(keySpecPKCS8);
+  }
+
+  // Base64 엔코딩된 공용키 문자열로부터 PublicKey를 얻는다. (broadcast 수신 후 publicKey 얻은 후 publicKeyMap에 저장)
+  public static PublicKey getPublicKeyFromBase64String(final String keyString) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    final String publicKeyString = keyString.replaceAll("\\n", "").replaceAll("-{5}[ a-zA-Z]*-{5}", "");
+    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+    X509EncodedKeySpec keySpecX509 = new X509EncodedKeySpec(Base64.getDecoder().decode(publicKeyString));
+    return keyFactory.generatePublic(keySpecX509);
+  }
+
+
 }


### PR DESCRIPTION
암호화 통신에 대한 준비입니다.

메소드 대부분을 넣어둔 상태입니다.

이후 필요 내용
1. LogIn시에 PublicKey Broadcast 및 수신
2. 메세지 발신 시 PublicKey로 Encryption 후 발신
3. 메세지 수신 시 PrivateKey로 Decryption 후 수신

1은 이벤트를 추가하면 됩니다.
2는 CMClientStub의 Chat메서드를 override하여 첫번째 파라메터인 strTarget은 그대로 둔 후 두번째 파라메터인 strMessage"만" 암호화 적용하면 될 것으로 보입니다.
3은 아직 발견못했습니다.